### PR TITLE
Bugfix: Fix users creation

### DIFF
--- a/MyMangas/Data/Network/DataSources/RemoteUserDataSource.swift
+++ b/MyMangas/Data/Network/DataSources/RemoteUserDataSource.swift
@@ -30,6 +30,10 @@ struct RemoteUserDataSource: UserDataSourceProtocol {
             throw NetworkError.status(response.statusCode)
         }
         
+        if U.self == Bool.self {
+            return true as! U
+        }
+        
         if let token = String(data: data, encoding: .utf8), !token.isEmpty {
             return token as! U
         }


### PR DESCRIPTION
This pull request introduces a small change to the `RemoteUserDataSource` class in `MyMangas/Data/Network/DataSources/RemoteUserDataSource.swift`. The change adds a conditional check to return `true` when the expected type `U` is `Bool`.

* [`MyMangas/Data/Network/DataSources/RemoteUserDataSource.swift`](diffhunk://#diff-c77c7c97d1c2055c1e454780732e931126fb57fb724ddbf1aa445d143e4a7413R33-R36): Added a conditional check in the `RemoteUserDataSource` to handle cases where the generic type `U` is `Bool`, returning `true` in such cases.